### PR TITLE
Fix issue with buffer cutting off JSON

### DIFF
--- a/integrations/scalyr/event_test.go
+++ b/integrations/scalyr/event_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func story(t *testing.T) *stories.Story {
-	story, err := stories.NewStory([]byte(`{
+	var story *stories.Story
+	err := json.Unmarshal([]byte(`{
     "severity": 4,
     "timestamp": "1541354132811",
     "message": "Hello world!",
@@ -20,7 +21,7 @@ func story(t *testing.T) *stories.Story {
       "boolean": true,
       "content": "Stuff"
     }
-  }`))
+  }`), &story)
 
 	if err != nil {
 		t.Fail()

--- a/integrations/scalyr/payload_test.go
+++ b/integrations/scalyr/payload_test.go
@@ -22,7 +22,8 @@ func instanceForInstanceTest(t *testing.T) *Instance {
 }
 
 func payloadForInstanceTest(t *testing.T) *Payload {
-	story, err := stories.NewStory([]byte(`{
+	var story *stories.Story
+	err := json.Unmarshal([]byte(`{
     "severity": 4,
     "timestamp": "1541354132811",
     "message": "Hello world!",
@@ -35,7 +36,7 @@ func payloadForInstanceTest(t *testing.T) *Payload {
       "boolean": true,
       "content": "Stuff"
     }
-  }`))
+  }`), &story)
 
 	if err != nil {
 		t.Fail()

--- a/stories/queue.go
+++ b/stories/queue.go
@@ -1,6 +1,7 @@
 package stories
 
 import (
+	"encoding/json"
 	"log"
 	"net"
 )
@@ -24,14 +25,10 @@ func NewQueueOfSize(size int) *Queue {
 
 func (q *Queue) Add(c net.Conn) error {
 	defer c.Close()
+	var story *Story
 
-	buf, nr, err := read(c)
-
-	if err != nil {
-		return err
-	}
-
-	story, err := NewStory(buf[:nr])
+	decoder := json.NewDecoder(c)
+	err := decoder.Decode(&story)
 
 	if err != nil {
 		return err
@@ -73,11 +70,4 @@ func (q *Queue) IsEmpty() bool {
 
 func (q *Queue) IsFull() bool {
 	return q.Size() >= q.Capacity()
-}
-
-func read(c net.Conn) ([]byte, int, error) {
-	buf := make([]byte, 2048)
-	nr, err := c.Read(buf)
-
-	return buf, nr, err
 }

--- a/stories/queue_test.go
+++ b/stories/queue_test.go
@@ -1,8 +1,8 @@
 package stories
 
 import (
+	"net"
 	"testing"
-  "net"
 )
 
 func TestQueueInitializedWithSize(t *testing.T) {
@@ -15,64 +15,64 @@ func TestQueueInitializedWithSize(t *testing.T) {
 }
 
 func TestCollectingWillClearTheQueue(t *testing.T) {
-  size := 10
+	size := 10
 	queue := NewQueueOfSize(size)
 
-  for i := 0; i < size; i++ {
-    server, client := net.Pipe()
-    go func() {
-      server.Write(storyJSON())
-      server.Close()
-    }()
+	for i := 0; i < size; i++ {
+		server, client := net.Pipe()
+		go func() {
+			server.Write(storyJSON())
+			server.Close()
+		}()
 
-    err := queue.Add(client)
-    
-    if err != nil {
-      t.Fatal(err)
-    }
-  }
+		err := queue.Add(client)
 
-  if queue.IsEmpty() {
-    t.Fatal("Queue should not have been empty")
-  }
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 
-  if len(queue.Collect()) != size {
-    t.Fatalf("Wanted a queue of %d. Got %d", queue.Capacity(), size)
-  }
+	if queue.IsEmpty() {
+		t.Fatal("Queue should not have been empty")
+	}
 
-  if queue.IsEmpty() != true {
-    t.Fatalf("Queue should have been empty, has a size of %d", queue.Capacity())
-  }
+	if len(queue.Collect()) != size {
+		t.Fatalf("Wanted a queue of %d. Got %d", queue.Capacity(), size)
+	}
+
+	if queue.IsEmpty() != true {
+		t.Fatalf("Queue should have been empty, has a size of %d", queue.Capacity())
+	}
 }
 
 func TestQueueIsFullAtMaxSize(t *testing.T) {
-  size := 10
+	size := 10
 	queue := NewQueueOfSize(size)
 
-  for i := 0; i < size; i++ {
-    server, client := net.Pipe()
-    go func() {
-      server.Write(storyJSON())
-      server.Close()
-    }()
+	for i := 0; i < size; i++ {
+		server, client := net.Pipe()
+		go func() {
+			server.Write(storyJSON())
+			server.Close()
+		}()
 
-    err := queue.Add(client)
-    
-    if err != nil {
-      t.Fatal(err)
-    }
-  }
+		err := queue.Add(client)
 
-  if queue.IsFull() != true {
-    t.Fatal("Queue should have been full")
-  }
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if queue.IsFull() != true {
+		t.Fatal("Queue should have been full")
+	}
 }
 
 func TestEmptyQueue(t *testing.T) {
-  size := 10
+	size := 10
 	queue := NewQueueOfSize(size)
 
-  if queue.IsEmpty() != true {
-    t.Fatal("Queue should have been empty")
-  }
+	if queue.IsEmpty() != true {
+		t.Fatal("Queue should have been empty")
+	}
 }

--- a/stories/story.go
+++ b/stories/story.go
@@ -11,21 +11,21 @@ type Story struct {
 	Data      map[string]json.RawMessage
 }
 
-func NewStory(bytes []byte) (*Story, error) {
-	var story Story
-	err := json.Unmarshal(bytes, &story)
+func (s *Story) UnmarshalJSON(bytes []byte) error {
+	type alias Story
+	err := json.Unmarshal(bytes, (*alias)(s))
 
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	if story.Data == nil {
-		story.Data = make(map[string]json.RawMessage)
+	if s.Data == nil {
+		s.Data = make(map[string]json.RawMessage)
 	}
 
-	if story.Severity == 0 {
-		story.Severity = 3
+	if s.Severity == 0 {
+		s.Severity = 3
 	}
 
-	return &story, nil
+	return nil
 }

--- a/stories/story_test.go
+++ b/stories/story_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func storyJSON() []byte {
-  return []byte(`{
+	return []byte(`{
     "severity": 4,
     "data": {
       "foo": {
@@ -22,8 +22,9 @@ func storyJSON() []byte {
   }`)
 }
 
-func TestNewStoryWithInvalidJSON(t *testing.T) {
-	story, err := NewStory([]byte("Invalid JSON"))
+func TestUnmarshalWithInvalidJSON(t *testing.T) {
+	var story *Story
+	err := json.Unmarshal([]byte("Invalid "), &story)
 
 	if story != nil {
 		t.Fail()
@@ -34,8 +35,9 @@ func TestNewStoryWithInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestNewStoryWithValidJSON(t *testing.T) {
-	story, err := NewStory([]byte(`{"foo": "bar"}`))
+func TestUnmarshalWithValidJSON(t *testing.T) {
+	var story *Story
+	err := json.Unmarshal([]byte(`{"foo": "bar"}`), &story)
 
 	if story == nil {
 		t.Error(err)
@@ -46,8 +48,9 @@ func TestNewStoryWithValidJSON(t *testing.T) {
 	}
 }
 
-func TestNewStoryHasDefaultSeverity(t *testing.T) {
-	story, err := NewStory([]byte("{\"foo\": \"bar\"}"))
+func TestUnmarshalHasDefaultSeverity(t *testing.T) {
+	var story *Story
+	err := json.Unmarshal([]byte("{\"foo\": \"bar\"}"), &story)
 
 	if err != nil {
 		t.Fail()
@@ -58,18 +61,19 @@ func TestNewStoryHasDefaultSeverity(t *testing.T) {
 	}
 }
 
-func TestNewStorySetsSeverityIfExists(t *testing.T) {
+func TestUnmarshalSetsSeverityIfExists(t *testing.T) {
+	var story *Story
 	sev := 4
 	data := make(map[string]interface{})
 	data["severity"] = sev
 
-	json, err := json.Marshal(data)
+	payload, err := json.Marshal(data)
 
 	if err != nil {
 		t.Error(err)
 	}
 
-	story, err := NewStory(json)
+	err = json.Unmarshal(payload, &story)
 
 	if err != nil {
 		t.Fail()
@@ -80,16 +84,17 @@ func TestNewStorySetsSeverityIfExists(t *testing.T) {
 	}
 }
 
-func TestNewStoryDataIsNeverNil(t *testing.T) {
+func TestUnmarshalDataIsNeverNil(t *testing.T) {
+	var story *Story
 	data := make(map[string]interface{})
 
-	json, err := json.Marshal(data)
+	payload, err := json.Marshal(data)
 
 	if err != nil {
 		t.Error(err)
 	}
 
-	story, err := NewStory(json)
+	err = json.Unmarshal(payload, &story)
 
 	if err != nil {
 		t.Fail()
@@ -100,16 +105,18 @@ func TestNewStoryDataIsNeverNil(t *testing.T) {
 	}
 }
 
-func TestNewStoryWithCompleteData(t *testing.T) {
-	event, err := NewStory(storyJSON())
+func TestUnmarshalWithCompleteData(t *testing.T) {
+	var event *Story
+	err := json.Unmarshal(storyJSON(), &event)
 
-	json, err := json.Marshal(event)
+	payload, err := json.Marshal(event)
 
 	if err != nil {
 		t.Error(err)
 	}
 
-	story, err := NewStory(json)
+	var story *Story
+	err = json.Unmarshal(payload, &story)
 
 	if err != nil {
 		t.Fail()


### PR DESCRIPTION
About 20% of the logs that are coming in exceed the buffer size that was
set. Also, I learnt that there is a better way to handle JSON payload
with Go.

Using the decoder means that implementing the Unmarshaller interface
allows the same behavior in a safer way.

The decoder also supports stream so it will parse the content no matter
the size of the JSON payload.