### PR TITLE
Only logs when debug is set to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ _default: /tmp/stories.sock_
 
 The path where the unix socket will be created. This is used by libraries to send over events.
 
+
+*`--debug=boolean`*
+
+_default: false_
+
+If you want to see debug logs, you need to set this to `true`. This should not be switched on in production.
+
 #### Batching against an interval
 
 The way the agent works is that there is a runloop set to the `interval` set at runtime that will send in batch any stories that were collected during the interval.

--- a/integrations/integrations.go
+++ b/integrations/integrations.go
@@ -9,14 +9,14 @@ import (
 
 type Integration interface {
 	Send([]*stories.Story) (*http.Response, error)
-	Configure() error
+	Configure(*bool) error
 }
 
-func Use(name string) (Integration, error) {
+func Use(name string, debug *bool) (Integration, error) {
 	switch name {
 	case "scalyr":
 		instance := &scalyr.Instance{}
-		err := instance.Configure()
+		err := instance.Configure(debug)
 		return instance, err
 	default:
 		return nil, errors.New("Invalid integration")

--- a/integrations/scalyr/instance.go
+++ b/integrations/scalyr/instance.go
@@ -19,13 +19,15 @@ type Instance struct {
 	Secret      string
 
 	configured bool
+	debug      bool
 }
 
-func (i *Instance) Configure() error {
+func (i *Instance) Configure(debug *bool) error {
 	if i.configured == true {
 		return errors.New("Instance already configured")
 	}
 
+	i.debug = *debug
 	i.Secret = os.Getenv("SCALYR_WRITE_TOKEN")
 
 	if len(i.Secret) == 0 {
@@ -47,8 +49,6 @@ func (i *Instance) Configure() error {
 }
 
 func (i *Instance) Send(stories []*stories.Story) (*http.Response, error) {
-	log.Printf("Sending %d stories.", len(stories))
-
 	client := &http.Client{
 		Timeout: time.Second * 10,
 	}
@@ -57,7 +57,10 @@ func (i *Instance) Send(stories []*stories.Story) (*http.Response, error) {
 
 	data, err := json.Marshal(payload)
 
-	log.Print(string(data))
+	if i.debug == true {
+		log.Printf("Sending %d stories.", len(stories))
+		log.Print(string(data))
+	}
 
 	if err != nil {
 		log.Print("Error creating a payload to send ", err)

--- a/integrations/scalyr/instance_test.go
+++ b/integrations/scalyr/instance_test.go
@@ -8,9 +8,10 @@ import (
 
 func TestConfigureInstanceGenerateASessionUUID(t *testing.T) {
 	os.Setenv("SCALYR_WRITE_TOKEN", "test")
+	debug := false
 
 	instance := &Instance{}
-	err := instance.Configure()
+	err := instance.Configure(&debug)
 
 	if err != nil {
 		t.Error(err)
@@ -22,12 +23,13 @@ func TestConfigureInstanceGenerateASessionUUID(t *testing.T) {
 }
 
 func TestConfigureMultipleTimeWontChangeSession(t *testing.T) {
+	debug := false
 	instance := &Instance{}
-	instance.Configure()
+	instance.Configure(&debug)
 
 	session := instance.Session.String()
 
-	instance.Configure()
+	instance.Configure(&debug)
 
 	if strings.Compare(session, instance.Session.String()) != 0 {
 		t.FailNow()

--- a/integrations/scalyr/payload_test.go
+++ b/integrations/scalyr/payload_test.go
@@ -9,9 +9,10 @@ import (
 
 func instanceForInstanceTest(t *testing.T) *Instance {
 	os.Setenv("SCALYR_WRITE_TOKEN", "test")
+	debug := false
 
 	instance := &Instance{}
-	err := instance.Configure()
+	err := instance.Configure(&debug)
 
 	if err != nil {
 		t.Error(err)

--- a/main.go
+++ b/main.go
@@ -19,11 +19,12 @@ func main() {
 	seconds := flag.Int("interval", 1, "seconds before sending stories")
 	integrationName := flag.String("integration", "scalyr", "integration to use with StoryTeller")
 	socketPath := flag.String("socket", "/tmp/stories.sock", "path of the socket created by this agent")
+	debug := flag.Bool("debug", false, "show debug logs")
 
 	flag.Parse()
 
 	queue = stories.NewQueueOfSize(*bufferSize)
-	integration, err := integrations.Use(*integrationName)
+	integration, err := integrations.Use(*integrationName, debug)
 
 	if err != nil {
 		log.Fatal("Couldn't configure integration: ", err)


### PR DESCRIPTION
It just makes sure that the agent doesn't write too much logs to stdout so the agent doesn't use too much IO in production. Might also makes it easier on CPU.

Close #7 